### PR TITLE
Add name to mpr_objs

### DIFF
--- a/include/mapper/mapper.h
+++ b/include/mapper/mapper.h
@@ -22,6 +22,19 @@ sure to consult the tutorial to get started with libmapper concepts.
 
      @{ Objects provide a generic representation of Devices, Signals, and Maps. */
 
+/*! Allocate and initialize an object.
+ *  \param name         A short descriptive string to identify the object.
+ *                      Must not contain spaces or the slash character '/'.
+ *  \param g            A previously allocated graph structure to use.
+ *                      If 0, one will be allocated for use with this device.
+ *  \return             A newly allocated object.  Should be freed
+ *                      using mpr_obj_free(). */
+mpr_obj mpr_obj_new(const char *name, mpr_graph g);
+
+/*! Free resources used by a object.
+ *  \param obj          The object to free. */
+void mpr_obj_free(mpr_obj obj);
+
 /*! Return the internal mpr_graph structure used by an object.
  *  \param obj          The object to query.
  *  \return             The mpr_graph used by this object. */

--- a/src/device.c
+++ b/src/device.c
@@ -66,7 +66,7 @@ void init_dev_prop_tbl(mpr_dev dev)
     mpr_list qry = mpr_list_new_query((const void**)&dev->obj.graph->devs,
                                       cmp_qry_linked, "v", &dev);
     mpr_tbl_link(tbl, PROP(LINKED), 1, MPR_LIST, qry, NON_MODIFIABLE | PROP_OWNED);
-    mpr_tbl_link(tbl, PROP(NAME), 1, MPR_STR, &dev->name, mod | INDIRECT | LOCAL_ACCESS_ONLY);
+    mpr_tbl_link(tbl, PROP(NAME), 1, MPR_STR, &dev->obj.name, mod | INDIRECT | LOCAL_ACCESS_ONLY);
     mpr_tbl_link(tbl, PROP(NUM_MAPS_IN), 1, MPR_INT32, &dev->num_maps_in, mod);
     mpr_tbl_link(tbl, PROP(NUM_MAPS_OUT), 1, MPR_INT32, &dev->num_maps_out, mod);
     mpr_tbl_link(tbl, PROP(NUM_SIGS_IN), 1, MPR_INT32, &dev->num_inputs, mod);
@@ -968,13 +968,13 @@ void mpr_dev_start_servers(mpr_dev dev)
 const char *mpr_dev_get_name(mpr_dev dev)
 {
     RETURN_UNLESS(!dev->loc || (dev->loc->registered && dev->loc->ordinal.locked), 0);
-    if (dev->name)
-        return dev->name;
+    if (dev->obj.name)
+        return dev->obj.name;
     unsigned int len = strlen(dev->prefix) + 6;
-    dev->name = (char*)malloc(len);
-    dev->name[0] = 0;
-    snprintf(dev->name, len, "%s.%d", dev->prefix, dev->loc->ordinal.val);
-    return dev->name;
+    dev->obj.name = (char*)malloc(len);
+    dev->obj.name[0] = 0;
+    snprintf(dev->obj.name, len, "%s.%d", dev->prefix, dev->loc->ordinal.val);
+    return dev->obj.name;
 }
 
 int mpr_dev_get_is_ready(mpr_dev dev)
@@ -1005,7 +1005,7 @@ void mpr_dev_send_state(mpr_dev dev, net_msg_t cmd)
     mpr_net net = &dev->obj.graph->net;
     if (cmd == MSG_DEV_MOD) {
         char str[1024];
-        snprintf(str, 1024, "/%s/modify", dev->name);
+        snprintf(str, 1024, "/%s/modify", dev->obj.name);
         mpr_net_add_msg(net, str, 0, msg);
         mpr_net_send(net);
     }
@@ -1062,7 +1062,7 @@ static int mpr_dev_update_linked(mpr_dev dev, mpr_msg_atom a)
             for (j = 0; j < num; j++) {
                 name = &link_list[j]->s;
                 name = name[0] == '/' ? name + 1 : name;
-                if (0 == strcmp(name, dev->linked[i]->name)) {
+                if (0 == strcmp(name, dev->linked[i]->obj.name)) {
                     found = 1;
                     break;
                 }

--- a/src/device.c
+++ b/src/device.c
@@ -310,7 +310,7 @@ int mpr_dev_handler(const char *path, const char *types, lo_arg **argv, int argc
 
     TRACE_RETURN_UNLESS(sig && (dev = sig->dev), 0, "error in mpr_dev_handler, "
                         "cannot retrieve user data\n");
-    TRACE_DEV_RETURN_UNLESS(sig->num_inst, 0, "signal '%s' has no instances.\n", sig->name);
+    TRACE_DEV_RETURN_UNLESS(sig->num_inst, 0, "signal '%s' has no instances.\n", sig->obj.name);
     RETURN_UNLESS(argc, 0);
 
     // We need to consider that there may be properties appended to the msg
@@ -616,7 +616,7 @@ mpr_sig mpr_dev_get_sig_by_name(mpr_dev dev, const char *sig_name)
     mpr_list sigs = mpr_list_from_data(dev->obj.graph->sigs);
     while (sigs) {
         mpr_sig sig = (mpr_sig)*sigs;
-        if ((sig->dev == dev) && strcmp(sig->name, skip_slash(sig_name))==0)
+        if ((sig->dev == dev) && strcmp(sig->obj.name, skip_slash(sig_name))==0)
             return sig;
         sigs = mpr_list_get_next(sigs);
     }

--- a/src/graph.c
+++ b/src/graph.c
@@ -513,7 +513,7 @@ static int _compare_slot_names(const void *l, const void *r)
 {
     int result = strcmp((*(mpr_slot*)l)->sig->dev->obj.name, (*(mpr_slot*)r)->sig->dev->obj.name);
     if (0 == result)
-        return strcmp((*(mpr_slot*)l)->sig->name, (*(mpr_slot*)r)->sig->name);
+        return strcmp((*(mpr_slot*)l)->sig->obj.name, (*(mpr_slot*)r)->sig->obj.name);
     return result;
 }
 
@@ -688,9 +688,9 @@ mpr_map mpr_graph_add_map(mpr_graph g, mpr_id id, int num_src, const char **src_
         if (!rc) {
             trace_graph("updated %d props for map [", updated);
             for (i = 0; i < map->num_src; i++) {
-                printf("%s:%s, ", map->src[i]->sig->dev->obj.name, map->src[i]->sig->name);
+                printf("%s:%s, ", map->src[i]->sig->dev->obj.name, map->src[i]->sig->obj.name);
             }
-            printf("\b\b] -> [%s:%s]\n", map->dst->sig->dev->obj.name, map->dst->sig->name);
+            printf("\b\b] -> [%s:%s]\n", map->dst->sig->dev->obj.name, map->dst->sig->obj.name);
         }
 #endif
         RETURN_UNLESS(map->status >= MPR_STATUS_ACTIVE, map);

--- a/src/graph.c
+++ b/src/graph.c
@@ -56,7 +56,7 @@ static void set_net_dst(mpr_graph g, mpr_dev d)
 static void send_subscribe_msg(mpr_graph g, mpr_dev d, int flags, int timeout)
 {
     char cmd[1024];
-    snprintf(cmd, 1024, "/%s/subscribe", d->name);
+    snprintf(cmd, 1024, "/%s/subscribe", d->obj.name);
 
     set_net_dst(g, d);
     NEW_LO_MSG(msg, return);
@@ -338,7 +338,7 @@ mpr_dev mpr_graph_add_dev(mpr_graph g, const char *name, mpr_msg msg)
     if (!dev) {
         trace_graph("adding device '%s'.\n", name);
         dev = (mpr_dev)mpr_list_add_item((void**)&g->devs, sizeof(*dev));
-        dev->name = strdup(no_slash);
+        dev->obj.name = strdup(no_slash);
         dev->obj.id = crc32(0L, (const Bytef *)no_slash, strlen(no_slash));
         dev->obj.id <<= 32;
         dev->obj.type = MPR_DEV;
@@ -382,7 +382,7 @@ void mpr_graph_remove_dev(mpr_graph g, mpr_dev d, mpr_graph_evt e, int quiet)
 
     FUNC_IF(mpr_tbl_free, d->obj.props.synced);
     FUNC_IF(mpr_tbl_free, d->obj.props.staged);
-    FUNC_IF(free, d->name);
+    FUNC_IF(free, d->obj.name);
     mpr_list_free_item(d);
 }
 
@@ -393,7 +393,7 @@ mpr_dev mpr_graph_get_dev_by_name(mpr_graph g, const char *name)
     while (devs) {
         mpr_dev dev = (mpr_dev)*devs;
         devs = mpr_list_get_next(devs);
-        if (dev->name && (0 == strcmp(dev->name, no_slash)))
+        if (dev->obj.name && (0 == strcmp(dev->obj.name, no_slash)))
             return dev;
     }
     return 0;
@@ -511,7 +511,7 @@ void mpr_graph_remove_link(mpr_graph g, mpr_link l, mpr_graph_evt e)
 
 static int _compare_slot_names(const void *l, const void *r)
 {
-    int result = strcmp((*(mpr_slot*)l)->sig->dev->name, (*(mpr_slot*)r)->sig->dev->name);
+    int result = strcmp((*(mpr_slot*)l)->sig->dev->obj.name, (*(mpr_slot*)r)->sig->dev->obj.name);
     if (0 == result)
         return strcmp((*(mpr_slot*)l)->sig->name, (*(mpr_slot*)r)->sig->name);
     return result;
@@ -688,9 +688,9 @@ mpr_map mpr_graph_add_map(mpr_graph g, mpr_id id, int num_src, const char **src_
         if (!rc) {
             trace_graph("updated %d props for map [", updated);
             for (i = 0; i < map->num_src; i++) {
-                printf("%s:%s, ", map->src[i]->sig->dev->name, map->src[i]->sig->name);
+                printf("%s:%s, ", map->src[i]->sig->dev->obj.name, map->src[i]->sig->name);
             }
-            printf("\b\b] -> [%s:%s]\n", map->dst->sig->dev->name, map->dst->sig->name);
+            printf("\b\b] -> [%s:%s]\n", map->dst->sig->dev->obj.name, map->dst->sig->name);
         }
 #endif
         RETURN_UNLESS(map->status >= MPR_STATUS_ACTIVE, map);

--- a/src/link.c
+++ b/src/link.c
@@ -41,7 +41,7 @@ void mpr_link_init(mpr_link link)
 
     // request missing metadata
     char cmd[256];
-    snprintf(cmd, 256, "/%s/subscribe", link->remote_dev->name);
+    snprintf(cmd, 256, "/%s/subscribe", link->remote_dev->obj.name);
     NEW_LO_MSG(m, return);
     lo_message_add_string(m, "device");
     mpr_net_use_bus(net);
@@ -63,7 +63,7 @@ void mpr_link_connect(mpr_link link, const char *host, int admin_port,
     sprintf(str, "%d", admin_port);
     link->addr.admin = lo_address_new(host, str);
     trace_dev(link->local_dev, "activated router to device '%s' at %s:%d\n",
-              link->remote_dev->name, host, data_port);
+              link->remote_dev->obj.name, host, data_port);
     memset(link->bundles, 0, sizeof(mpr_bundle_t) * NUM_BUNDLES);
     mpr_dev_add_link(link->local_dev, link->remote_dev);
 }
@@ -198,9 +198,9 @@ void mpr_link_remove_map(mpr_link link, mpr_map rem)
 void mpr_link_send(mpr_link link, net_msg_t cmd)
 {
     NEW_LO_MSG(msg, return);
-    lo_message_add_string(msg, link->devs[0]->name);
+    lo_message_add_string(msg, link->devs[0]->obj.name);
     lo_message_add_string(msg, "<->");
-    lo_message_add_string(msg, link->devs[1]->name);
+    lo_message_add_string(msg, link->devs[1]->obj.name);
     mpr_net_add_msg(&link->obj.graph->net, 0, cmd, msg);
 }
 

--- a/src/map.c
+++ b/src/map.c
@@ -37,7 +37,7 @@ static int _sort_sigs(int num, mpr_sig *s, int *o)
             if (res1 < 0)
                 break;
             else if (0 == res1) {
-                res2 = strcmp(s[o[j]]->name, s[o[j+1]]->name);
+                res2 = strcmp(s[o[j]]->obj.name, s[o[j+1]]->obj.name);
                 if (0 == res2) {
                     // abort: identical signal names
                     return 1;
@@ -113,10 +113,10 @@ mpr_map mpr_map_new(int num_src, mpr_sig *src, int num_dst, mpr_sig *dst)
     int i, j;
     for (i = 0; i < num_src; i++) {
         for (j = 0; j < num_dst; j++) {
-            if (   strcmp(src[i]->name, dst[j]->name)==0
+            if (   strcmp(src[i]->obj.name, dst[j]->obj.name)==0
                 && strcmp(src[i]->dev->obj.name, dst[j]->dev->obj.name)==0) {
                 trace("Cannot connect signal '%s:%s' to itself.\n",
-                      mpr_dev_get_name(src[i]->dev), src[i]->name);
+                      mpr_dev_get_name(src[i]->dev), src[i]->obj.name);
                 return 0;
             }
         }
@@ -168,7 +168,7 @@ mpr_map mpr_map_new(int num_src, mpr_sig *src, int num_dst, mpr_sig *dst)
         if (src[order[i]]->dev->obj.graph == g)
             o = (mpr_obj)src[order[i]];
         else if (!(o = mpr_graph_get_obj(g, MPR_SIG, src[order[i]]->obj.id))) {
-            o = (mpr_obj)mpr_graph_add_sig(g, src[order[i]]->name, src[order[i]]->dev->obj.name, 0);
+            o = (mpr_obj)mpr_graph_add_sig(g, src[order[i]]->obj.name, src[order[i]]->dev->obj.name, 0);
             if (!o->id) {
                 o->id = src[order[i]]->obj.id;
                 ((mpr_sig)o)->dir = src[order[i]]->dir;

--- a/src/map.c
+++ b/src/map.c
@@ -33,7 +33,7 @@ static int _sort_sigs(int num, mpr_sig *s, int *o)
     for (i = 1; i < num; i++) {
         j = i-1;
         while (j >= 0) {
-            res1 = strcmp(s[o[j]]->dev->name, s[o[j+1]]->dev->name);
+            res1 = strcmp(s[o[j]]->dev->obj.name, s[o[j+1]]->dev->obj.name);
             if (res1 < 0)
                 break;
             else if (0 == res1) {
@@ -114,7 +114,7 @@ mpr_map mpr_map_new(int num_src, mpr_sig *src, int num_dst, mpr_sig *dst)
     for (i = 0; i < num_src; i++) {
         for (j = 0; j < num_dst; j++) {
             if (   strcmp(src[i]->name, dst[j]->name)==0
-                && strcmp(src[i]->dev->name, dst[j]->dev->name)==0) {
+                && strcmp(src[i]->dev->obj.name, dst[j]->dev->obj.name)==0) {
                 trace("Cannot connect signal '%s:%s' to itself.\n",
                       mpr_dev_get_name(src[i]->dev), src[i]->name);
                 return 0;
@@ -168,7 +168,7 @@ mpr_map mpr_map_new(int num_src, mpr_sig *src, int num_dst, mpr_sig *dst)
         if (src[order[i]]->dev->obj.graph == g)
             o = (mpr_obj)src[order[i]];
         else if (!(o = mpr_graph_get_obj(g, MPR_SIG, src[order[i]]->obj.id))) {
-            o = (mpr_obj)mpr_graph_add_sig(g, src[order[i]]->name, src[order[i]]->dev->name, 0);
+            o = (mpr_obj)mpr_graph_add_sig(g, src[order[i]]->name, src[order[i]]->dev->obj.name, 0);
             if (!o->id) {
                 o->id = src[order[i]]->obj.id;
                 ((mpr_sig)o)->dir = src[order[i]]->dir;
@@ -290,11 +290,11 @@ void mpr_map_add_scope(mpr_map m, mpr_dev d)
             names[0] = (const char*)r->val;
         for (int i = 0; i < r->len; i++)
             names[i] = ((const char**)r->val)[i];
-        names[r->len] = d ? d->name : "all";
+        names[r->len] = d ? d->obj.name : "all";
         mpr_tbl_set(m->obj.props.staged, p, NULL, r->len + 1, MPR_STR, names, REMOTE_MODIFY);
     }
     else
-        mpr_tbl_set(m->obj.props.staged, p, NULL, 1, MPR_STR, d->name, REMOTE_MODIFY);
+        mpr_tbl_set(m->obj.props.staged, p, NULL, 1, MPR_STR, d->obj.name, REMOTE_MODIFY);
 }
 
 /* Here we do not edit the "scope" property directly – instead we stage a the
@@ -308,13 +308,13 @@ void mpr_map_remove_scope(mpr_map m, mpr_dev d)
     if (r && MPR_STR == r->type) {
         const char *names[r->len];
         if (1 == r->len) {
-            if (0 == strcmp((const char*)r->val, d->name))
+            if (0 == strcmp((const char*)r->val, d->obj.name))
                 mpr_tbl_remove(t, p, NULL, REMOTE_MODIFY);
         }
         else {
             int i = 0, j = 0;
             for (; i < r->len; i++) {
-                if (0 != strcmp(((const char**)r->val)[i], d->name))
+                if (0 != strcmp(((const char**)r->val)[i], d->obj.name))
                     names[j++] = ((const char**)r->val)[i];
             }
             if (j != i)
@@ -322,7 +322,7 @@ void mpr_map_remove_scope(mpr_map m, mpr_dev d)
         }
     }
     else
-        mpr_tbl_set(t, p, NULL, 1, MPR_STR, d->name, REMOTE_MODIFY);
+        mpr_tbl_set(t, p, NULL, 1, MPR_STR, d->obj.name, REMOTE_MODIFY);
 }
 
 static int _add_scope(mpr_map m, const char *name)
@@ -363,7 +363,7 @@ static int _remove_scope(mpr_map m, const char *name)
             if (!name)
                 break;
         }
-        else if (name && strcmp(m->scopes[i]->name, name) == 0)
+        else if (name && strcmp(m->scopes[i]->obj.name, name) == 0)
             break;
     }
     if (i == m->num_scopes)
@@ -397,13 +397,13 @@ static int _update_scope(mpr_map m, mpr_msg_atom a)
                     }
                     break;
                 }
-                if (strcmp(name, m->scopes[i]->name) == 0) {
+                if (strcmp(name, m->scopes[i]->obj.name) == 0) {
                     found = 1;
                     break;
                 }
             }
             if (!found && m->scopes[i])
-                updated += _remove_scope(m, m->scopes[i]->name);
+                updated += _remove_scope(m, m->scopes[i]->obj.name);
             else
                 ++i;
         }
@@ -1285,7 +1285,7 @@ int mpr_map_send_state(mpr_map m, int slot, net_msg_t cmd)
         return slot;
     NEW_LO_MSG(msg, return slot);
     char dst_name[256], src_names[1024];
-    snprintf(dst_name, 256, "%s%s", m->dst->sig->dev->name, m->dst->sig->path);
+    snprintf(dst_name, 256, "%s%s", m->dst->sig->dev->obj.name, m->dst->sig->path);
     if (MPR_DIR_IN == m->dst->dir) {
         // add mapping destination
         lo_message_add_string(msg, dst_name);
@@ -1300,7 +1300,7 @@ int mpr_map_send_state(mpr_map m, int slot, net_msg_t cmd)
         if ((slot >= 0) && link && (link != m->src[i]->link))
             break;
         result = snprintf(&src_names[len], 1024-len, "%s%s",
-                          m->src[i]->sig->dev->name, m->src[i]->sig->path);
+                          m->src[i]->sig->dev->obj.name, m->src[i]->sig->path);
         if (result < 0 || (len + result + 1) >= 1024) {
             trace("Error encoding sources for combined /mapped msg");
             lo_message_free(msg);

--- a/src/network.c
+++ b/src/network.c
@@ -1121,7 +1121,7 @@ static int handler_sig_mod(const char *path, const char *types, lo_arg **av,
     TRACE_DEV_RETURN_UNLESS(sig, 0, "no signal found with name '%s'.\n", &av[0]->s);
 
     mpr_msg props = mpr_msg_parse_props(ac-1, &types[1], &av[1]);
-    trace_dev(dev, "received %s '%s' + %d properties.\n", path, sig->name, props->num_atoms);
+    trace_dev(dev, "received %s '%s' + %d properties.\n", path, sig->obj.name, props->num_atoms);
 
     if (mpr_sig_set_from_msg(sig, props)) {
         if (dev->loc->subscribers) {
@@ -1366,8 +1366,8 @@ static mpr_map find_map(mpr_net net, const char *types, int ac, lo_arg **av,
 #ifdef DEBUG
             trace_graph("  %s", map->num_src > 1 ? "[" : "");
             for (i = 0; i < map->num_src; i++)
-                printf("'%s', ", map->src[i]->sig->name);
-            printf("\b\b%s -> '%s'\n", map->num_src > 1 ? "]" : "", map->dst->sig->name);
+                printf("'%s', ", map->src[i]->sig->obj.name);
+            printf("\b\b%s -> '%s'\n", map->num_src > 1 ? "]" : "", map->dst->sig->obj.name);
 #endif
             is_loc = mpr_obj_get_prop_as_int32((mpr_obj)map, MPR_PROP_IS_LOCAL, NULL);
             RETURN_UNLESS(!loc || is_loc, MPR_MAP_ERROR);

--- a/src/network.c
+++ b/src/network.c
@@ -646,7 +646,7 @@ static void mpr_net_maybe_send_ping(mpr_net net, int force)
             if (clk->rcvd.msg_id > 0) {
                 if (num_maps)
                     trace_dev(lnk->local_dev, "Lost contact with linked device '%s' (%g seconds "
-                              "since sync).\n", lnk->remote_dev->name, elapsed);
+                              "since sync).\n", lnk->remote_dev->obj.name, elapsed);
                 // tentatively mark link as expired
                 clk->rcvd.msg_id = -1;
                 clk->rcvd.time.sec = now.sec;
@@ -654,13 +654,13 @@ static void mpr_net_maybe_send_ping(mpr_net net, int force)
             else {
                 if (num_maps) {
                     trace_dev(lnk->local_dev, "Removing link to unresponsive device '%s' (%g "
-                              "seconds since warning).\n", lnk->remote_dev->name, elapsed);
+                              "seconds since warning).\n", lnk->remote_dev->obj.name, elapsed);
                     /* TODO: release related maps, call local handlers
                      * and inform subscribers. */
                 }
                 else
                     trace_dev(lnk->local_dev, "Removing link to device '%s'.\n",
-                              lnk->remote_dev->name);
+                              lnk->remote_dev->obj.name);
                 // remove related data structures
                 mpr_rtr_remove_link(net->rtr, lnk);
                 mpr_graph_remove_link(gph, lnk, num_maps ? MPR_OBJ_EXP : MPR_OBJ_REM);
@@ -1832,7 +1832,7 @@ static int handler_ping(const char *path, const char *types, lo_arg **av,
     lnk = remote ? mpr_dev_get_link_by_remote(dev, remote) : 0;
     if (lnk) {
         mpr_sync_clock clk = &lnk->clock;
-        trace_dev(dev, "ping received from linked device '%s'\n", lnk->remote_dev->name);
+        trace_dev(dev, "ping received from linked device '%s'\n", lnk->remote_dev->obj.name);
         if (av[2]->i == clk->sent.msg_id) {
             // total elapsed time since ping sent
             double elapsed = mpr_time_get_diff(now, clk->sent.time);
@@ -1882,7 +1882,7 @@ static int handler_sync(const char *path, const char *types, lo_arg **av,
     mpr_dev dev = mpr_graph_get_dev_by_name(graph, &av[0]->s);
     if (dev) {
         RETURN_UNLESS(!dev->loc, 0);
-        trace_graph("updating sync record for device '%s'\n", dev->name);
+        trace_graph("updating sync record for device '%s'\n", dev->obj.name);
         mpr_time_set(&dev->synced, MPR_NOW);
 
         if (!dev->subscribed && graph->autosub) {
@@ -1894,7 +1894,7 @@ static int handler_sync(const char *path, const char *types, lo_arg **av,
         // only create device record after requesting more information
         trace_net("requesting metadata for device '%s'.\n", &av[0]->s);
         mpr_dev_t temp;
-        temp.name = &av[0]->s;
+        temp.obj.name = &av[0]->s;
         temp.obj.version = -1;
         temp.loc = 0;
         mpr_graph_subscribe(graph, &temp, MPR_DEV, 0);

--- a/src/object.c
+++ b/src/object.c
@@ -288,3 +288,38 @@ void mpr_obj_print(mpr_obj o, int staged)
     }
     printf("\n");
 }
+
+/* TODO: Move to proper spot when deemed complete. */
+mpr_obj mpr_obj_new(const char *name, mpr_graph g){
+    RETURN_UNLESS(name);
+    TRACE_RETURN_UNLESS(name[strlen(name)-1] != '/', 0,
+                        "trailing slash detected in object name.\n");
+
+    if (!g) {
+        g = mpr_graph_new(0);
+        g->own = 0;
+    }
+
+    mpr_obj obj = (mpr_obj*)malloc(sizeof(mpr_obj_t)); // Is this correct?
+    obj->type = MPR_OBJ;
+
+    obj->name = (char*)malloc(strlen(name));
+    obj->graph = g;
+
+    return obj;
+}
+
+void mpr_obj_free(mpr_obj obj){
+    RETURN_UNLESS(obj);
+    
+    // Free name
+    free(obj->name);
+
+    // Free graph if appropriate
+
+
+    // Free children objects
+    // Todo: Once nested mpr_obj branch is merged, be sure to free mpr_obj children also.
+
+
+}

--- a/src/properties.c
+++ b/src/properties.c
@@ -628,13 +628,13 @@ void mpr_prop_print(int len, mpr_type type, const void *val)
             // just print signal name
             if (1 == len) {
                 mpr_sig sig = (mpr_sig)val;
-                printf("'%s:%s', ", mpr_dev_get_name(sig->dev), sig->name);
+                printf("'%s:%s', ", mpr_dev_get_name(sig->dev), sig->obj.name);
             }
             else {
                 mpr_sig *sig = (mpr_sig*)val;
                 for (i = 0; i < len; i++)
                     printf("'%s:%s', ", mpr_dev_get_name(sig[i]->dev),
-                           sig[i]->name);
+                           sig[i]->obj.name);
             }
             break;
         }

--- a/src/router.c
+++ b/src/router.c
@@ -83,7 +83,7 @@ void mpr_rtr_process_sig(mpr_rtr rtr, mpr_sig sig, int idmap_idx, const void *va
 {
     // abort if signal is already being processed - might be a local loop
     if (sig->loc->locked) {
-        trace_dev(rtr->dev, "Mapping loop detected on signal %s! (1)\n", sig->name);
+        trace_dev(rtr->dev, "Mapping loop detected on signal %s! (1)\n", sig->obj.name);
         return;
     }
     mpr_id_map idmap = sig->loc->idmaps[idmap_idx].map;

--- a/src/signal.c
+++ b/src/signal.c
@@ -934,7 +934,7 @@ void mpr_sig_send_state(mpr_sig s, net_msg_t cmd)
         /* properties */
         mpr_tbl_add_to_msg(s->loc ? s->obj.props.synced : 0, s->obj.props.staged, msg);
 
-        snprintf(str, 1024, "/%s/signal/modify", s->dev->name);
+        snprintf(str, 1024, "/%s/signal/modify", s->dev->obj.name);
         mpr_net_add_msg(&s->obj.graph->net, str, 0, msg);
         // send immediately since path string is not cached
         mpr_net_send(&s->obj.graph->net);

--- a/src/slot.c
+++ b/src/slot.c
@@ -140,7 +140,7 @@ int mpr_slot_match_full_name(mpr_slot slot, const char *full_name)
     int len = sig_name - full_name;
     const char *dev_name = slot->sig->dev->obj.name;
     return (strlen(dev_name) != len || strncmp(full_name, dev_name, len)
-            || strcmp(sig_name+1, slot->sig->name)) ? 1 : 0;
+            || strcmp(sig_name+1, slot->sig->obj.name)) ? 1 : 0;
 }
 
 void mpr_slot_alloc_values(mpr_slot slot, int num_inst, int hist_size)

--- a/src/slot.c
+++ b/src/slot.c
@@ -138,7 +138,7 @@ int mpr_slot_match_full_name(mpr_slot slot, const char *full_name)
     const char *sig_name = strchr(full_name+1, '/');
     RETURN_UNLESS(sig_name, 1);
     int len = sig_name - full_name;
-    const char *dev_name = slot->sig->dev->name;
+    const char *dev_name = slot->sig->dev->obj.name;
     return (strlen(dev_name) != len || strncmp(full_name, dev_name, len)
             || strcmp(sig_name+1, slot->sig->name)) ? 1 : 0;
 }

--- a/src/types_internal.h
+++ b/src/types_internal.h
@@ -338,7 +338,7 @@ typedef struct _mpr_sig {
     mpr_local_sig loc;
     mpr_dev dev;
     char *path;             //! OSC path.  Must start with '/'.
-    char *name;             //! The name of this signal (path+1).
+    // char *name;             //! The name of this signal (path+1).
 
     char *unit;             //!< The unit of this signal, or NULL for N/A.
     void *min;              //!< The minimum of this signal, or NULL for N/A.

--- a/src/types_internal.h
+++ b/src/types_internal.h
@@ -252,6 +252,7 @@ typedef struct _mpr_obj
 {
     mpr_graph graph;                //!< Pointer back to the graph.
     mpr_id id;                      //!< Unique id for this object.
+    char *name;                     //!< The full name for this object, or zero.
     void *data;                     //!< User context pointer.
     struct _mpr_dict props;         //!< Properties associated with this signal.
     int version;                    //!< Version number.

--- a/src/types_internal.h
+++ b/src/types_internal.h
@@ -518,7 +518,7 @@ struct _mpr_dev {
     mpr_dev *linked;
 
     char *prefix;               //!< The identifier (prefix) for this device.
-    char *name;                 //!< The full name for this device, or zero.
+    // char *name;                 //!< The full name for this device, or zero.
 
     mpr_time synced;            //!< Timestamp of last sync.
 

--- a/test/testmapfail.c
+++ b/test/testmapfail.c
@@ -142,7 +142,7 @@ void loop()
     eprintf("Polling device..\n");
     int i = 0;
     while ((!terminate || srcgraph->links || dstgraph->links) && !done) {
-        eprintf("Updating signal %s to %d\n", sendsig->name, i);
+        eprintf("Updating signal %s to %d\n", sendsig->obj.name, i);
         mpr_sig_set_value(sendsig, 0, 1, MPR_INT32, &i);
         sent++;
         mpr_dev_poll(src, 0);

--- a/test/testunmap.c
+++ b/test/testunmap.c
@@ -141,7 +141,7 @@ void loop()
     while ((!terminate || srcgraph->links || dstgraph->links) && !done) {
         mpr_dev_poll(src, 0);
         eprintf("Updating signal %s to %d\n",
-                sendsig && sendsig->name ? sendsig->name : "", i);
+                sendsig && sendsig->obj.name ? sendsig->obj.name : "", i);
         mpr_sig_set_value(sendsig, 0, 1, MPR_INT32, &i);
         sent++;
         mpr_dev_poll(dst, 100);

--- a/test/testvector.c
+++ b/test/testvector.c
@@ -165,7 +165,7 @@ void loop()
             v[j] = (float)(i + j);
             expected[j] = (double)v[j] * M[j] + B[j];
         }
-        eprintf("Updating signal %s to [", sendsig->name);
+        eprintf("Updating signal %s to [", sendsig->obj.name);
         for (j = 0; j < vec_len; j++)
             eprintf("%f, ", v[j]);
         eprintf("\b\b]\n");


### PR DESCRIPTION
This pull request adds a name field to the `mpr_obj` struct and uses that names instead of the name found in `mpr_dev` for all occurrences.

The name field in `mpr_dev` is commented out, but not deleted. Will there ever be a need for a `mpr_dev` to have a name that is different than its nested `mpr_obj.name`??

Tests pass after this refactor.